### PR TITLE
hide not upgraded fruits from inventory

### DIFF
--- a/src/dapp/components/ui/Plants.tsx
+++ b/src/dapp/components/ui/Plants.tsx
@@ -39,7 +39,7 @@ export const Plants: React.FC<Props> = ({
         <div id="crafting-items">
           {fruits.map((fruit) => (
             (fruit.landRequired > land.length) ?
-              (<Box />)
+              (<Box disabled/>)
             : (<Box
               isSelected={fruit.fruit === plant.fruit}
               onClick={() => onSelectItem(fruit)}

--- a/src/dapp/components/ui/Plants.tsx
+++ b/src/dapp/components/ui/Plants.tsx
@@ -38,12 +38,12 @@ export const Plants: React.FC<Props> = ({
       <div id="crafting-left">
         <div id="crafting-items">
           {fruits.map((fruit) => (
-            <Box
+            !(fruit.landRequired > land.length) && (<Box
               isSelected={fruit.fruit === plant.fruit}
               onClick={() => onSelectItem(fruit)}
             >
               <img src={fruit.image} className="box-item" />
-            </Box>
+            </Box>)
           ))}
         </div>
       </div>

--- a/src/dapp/components/ui/Plants.tsx
+++ b/src/dapp/components/ui/Plants.tsx
@@ -38,7 +38,9 @@ export const Plants: React.FC<Props> = ({
       <div id="crafting-left">
         <div id="crafting-items">
           {fruits.map((fruit) => (
-            !(fruit.landRequired > land.length) && (<Box
+            (fruit.landRequired > land.length) ?
+              (<Box />)
+            : (<Box
               isSelected={fruit.fruit === plant.fruit}
               onClick={() => onSelectItem(fruit)}
             >


### PR DESCRIPTION
This PR will hide disabled (yet not upgraded) fruits from inventory.


## To test:
* Open inventory and check if fruits yet not upgraded show.

## Image:
* Radishes yet not upgraded...
![Screen Shot 2021-11-20 at 2 03 39 pm](https://user-images.githubusercontent.com/25412194/142712402-24df0e5d-93d1-4798-85fd-9fc79c0667fd.png)
 
