### PR TITLE
Resolve NaN NFT count display

### DIFF
--- a/src/dapp/components/ui/CraftingMenu.tsx
+++ b/src/dapp/components/ui/CraftingMenu.tsx
@@ -185,7 +185,7 @@ export const CraftingMenu: React.FC<Props> = ({
         >
           {selectedRecipe.type}
         </span>
-        {selectedRecipe.supply && (
+        {selectedRecipe.supply && !isNaN(amountLeft) && (
           <span className="nft-count">{`${amountLeft} left!`}</span>
         )}
         <span id="recipe-title">{selectedRecipe.name}</span>


### PR DESCRIPTION
Presently, for items not wholly available yet in the `Blockchain` component that are flagged as NFTs, the number "left" is listed as `NaN`. This PR will remove such behaviour _only_ if invalid, in order to prevent confusion with users.

### Example of old behaviour:
<img width="215" alt="Bildschirmfoto 2021-12-04 um 20 20 38" src="https://user-images.githubusercontent.com/3837103/144729699-1661fe99-bd47-4607-a42f-1571050c107d.png">

### Example of fixed behaviour:
<img width="231" alt="Bildschirmfoto 2021-12-04 um 20 20 28" src="https://user-images.githubusercontent.com/3837103/144729696-aa1b86f6-c2ec-4404-9d13-0606c7625f47.png">
