### PR TITLE
Transition to Loading state on NETWORK_CHANGED event

### DIFF
--- a/src/dapp/machine.ts
+++ b/src/dapp/machine.ts
@@ -310,6 +310,10 @@ export const blockChainMachine = createMachine<
           target: "loading",
           actions: (context) => context.blockChain.resetFarm(),
         },
+        NETWORK_CHANGED: {
+          target: "loading",
+          actions: (context) => context.blockChain.resetFarm(),
+        },
       },
     },
     warning: {


### PR DESCRIPTION
This PR is resolution for #24 

On `farming` state, include `NETWORK_CHANGED` event which transitions to `loading` state

Pros(?):
- similar behavior with `ACCOUNT_CHANGED` event

Cons:
- unsaved actions will be reset -- do users interact w/ dapps on other chains while waiting to harvest?
