### PR TITLE
Resolve z-fighting of the bald man NPC and the nearest gold miner NPC

### DIFF
--- a/src/dapp/components/farm/Gold.css
+++ b/src/dapp/components/farm/Gold.css
@@ -1,0 +1,27 @@
+.game-object.gold .boundary {
+  width: 80px;
+  height: 100px;
+  overflow: hidden;
+  position: absolute;
+  top: -33px;
+  right: -60px;
+}
+
+/*
+ * NOTE: ore shares logic with other resources; but never scales past
+ * 48px; this hardcodes it (least for gold) until it can be separated
+ */
+.game-object.gold .ore {
+  max-width: 48px;
+}
+
+.game-object.gold .miner {
+  position: relative;
+  top: calc(50% - 61px);
+  right: calc(50% + 17px);
+}
+
+.game-object.gold .miner-question {
+  top: 9px;
+  right: 34px;
+}

--- a/src/dapp/components/farm/Gold.tsx
+++ b/src/dapp/components/farm/Gold.tsx
@@ -129,12 +129,14 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
         return (
           <div
             style={gridPosition}
-            className={classnames("gather-tree", {
-              "gatherer-selected": isHighlighted,
-              gatherer: isNextToChop,
-              "game-object": true,
-              gold: true,
-            })}
+            className={classnames(
+              "gather-tree", 
+              "game-object",
+              "gold", {
+                "gatherer-selected": isHighlighted,
+                gatherer: isNextToChop,
+              }
+            )}
             onClick={isNextToChop ? open : undefined}
           >
             <img src={rock} className="rock-mine ore" alt="tree" />

--- a/src/dapp/components/farm/Gold.tsx
+++ b/src/dapp/components/farm/Gold.tsx
@@ -30,6 +30,7 @@ import {
 import { Inventory, items } from "../../types/crafting";
 
 import "./Trees.css";
+import "./Gold.css";
 
 const ROCKS: React.CSSProperties[] = [
   {
@@ -125,42 +126,18 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
           !machineState.matches("mining") &&
           (isNextToChop || isHighlighted);
 
-        const waitingBoundLimiterContainerStyle = {
-          width: "80px",
-          overflow: "hidden",
-          height: "100px",
-          position: "absolute",
-          right: "-60px",
-          top: "-33px",
-        }
-
-        // NOTE: ore shares logic with other resources, but never scales past
-        // 48px; this hardcodes it (least for gold) until it can be separated
-        const waitingBoundLimiterOreStyle = {
-          maxWidth: "48px",
-        }
-
-        const waitingBoundLimiterMinerStyle = {
-          position: "relative",
-          right: "calc(50% + 17px)",
-          top: "calc(50% - 61px)",
-        }
-
-        const waitingBoundLimiterMinerQuestion = {
-          right: "34px",
-          top: "9px",
-        }
-
         return (
           <div
             style={gridPosition}
             className={classnames("gather-tree", {
               "gatherer-selected": isHighlighted,
               gatherer: isNextToChop,
+              "game-object": true,
+              gold: true,
             })}
             onClick={isNextToChop ? open : undefined}
           >
-            <img src={rock} className="rock-mine" alt="tree" style={waitingBoundLimiterOreStyle} />
+            <img src={rock} className="rock-mine ore" alt="tree" />
             {isHighlighted && machineState.matches("mining") && (
               <>
                 <img src={mining} className="miner" />
@@ -171,9 +148,9 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
               </>
             )}
             {showWaiting && (
-              <div style={waitingBoundLimiterContainerStyle}>
-                <img src={waiting} style={waitingBoundLimiterMinerStyle} className="miner" />
-                <img src={questionMark} style={waitingBoundLimiterMinerQuestion} className="miner-question" />
+              <div className="boundary">
+                <img src={waiting} className="miner" />
+                <img src={questionMark} className="miner-question" />
               </div>
             )}
           </div>

--- a/src/dapp/components/farm/Gold.tsx
+++ b/src/dapp/components/farm/Gold.tsx
@@ -69,7 +69,7 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
       load();
       setAmount(0);
     }
-  }, [machineState.value]);
+  }, [machineState, machineState.value]);
 
   useEffect(() => {
     const change = machineState.context.blockChain.getInventoryChange();
@@ -79,7 +79,7 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
       setShowChoppedCount(true);
       setTimeout(() => setShowChoppedCount(false), 3000);
     }
-  }, [machineState.value, inventory]);
+  }, [machineState.value, inventory, machineState.context.blockChain]);
 
   const chop = () => {
     send("MINE", {
@@ -125,6 +125,32 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
           !machineState.matches("mining") &&
           (isNextToChop || isHighlighted);
 
+        const waitingBoundLimiterContainerStyle = {
+          width: "80px",
+          overflow: "hidden",
+          height: "100px",
+          position: "absolute",
+          right: "-60px",
+          top: "-33px",
+        }
+
+        // NOTE: ore shares logic with other resources, but never scales past
+        // 48px; this hardcodes it (least for gold) until it can be separated
+        const waitingBoundLimiterOreStyle = {
+          maxWidth: "48px",
+        }
+
+        const waitingBoundLimiterMinerStyle = {
+          position: "relative",
+          right: "calc(50% + 17px)",
+          top: "calc(50% - 61px)",
+        }
+
+        const waitingBoundLimiterMinerQuestion = {
+          right: "34px",
+          top: "9px",
+        }
+
         return (
           <div
             style={gridPosition}
@@ -134,7 +160,7 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
             })}
             onClick={isNextToChop ? open : undefined}
           >
-            <img src={rock} className="rock-mine" alt="tree" />
+            <img src={rock} className="rock-mine" alt="tree" style={waitingBoundLimiterOreStyle} />
             {isHighlighted && machineState.matches("mining") && (
               <>
                 <img src={mining} className="miner" />
@@ -145,9 +171,9 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
               </>
             )}
             {showWaiting && (
-              <div>
-                <img src={waiting} className="miner" />
-                <img src={questionMark} className="miner-question" />
+              <div style={waitingBoundLimiterContainerStyle}>
+                <img src={waiting} style={waitingBoundLimiterMinerStyle} className="miner" />
+                <img src={questionMark} style={waitingBoundLimiterMinerQuestion} className="miner-question" />
               </div>
             )}
           </div>


### PR DESCRIPTION
If the gold miner positioned closest to the bald man is active, the bounding box has z-fighting issues. This makes it difficult to click either one. This PR resolves that.

#### Before:

https://user-images.githubusercontent.com/3837103/147791419-b6221bb2-dfc1-477e-b168-a5a53e09c1c9.mov

#### Fixed:

https://user-images.githubusercontent.com/3837103/147791426-4562ea47-f96a-4935-b15c-439c7f2c2f80.mov
