### PR TITLE
Fix UI reflow when mining gold

### DIFF
--- a/src/dapp/components/farm/Gold.css
+++ b/src/dapp/components/farm/Gold.css
@@ -1,0 +1,37 @@
+.game-object.gold .boundary {
+  width: 80px;
+  height: 100px;
+  overflow: hidden;
+  position: absolute;
+  top: -33px;
+  right: -60px;
+}
+
+.game-object.gold .boundary.show-overflow {
+  overflow: visible;
+}
+
+/*
+ * NOTE: ore shares logic with other resources; but never scales past
+ * 48px; this hardcodes it (least for gold) until it can be separated
+ */
+.game-object.gold .ore {
+  max-width: 48px;
+}
+
+.game-object.gold .miner {
+  position: relative;
+  top: calc(50% - 61px);
+  right: calc(50% + 17px);
+}
+
+.game-object.gold .miner {
+  position: relative;
+  top: calc(50% - 61px);
+  right: calc(50% + 17px);
+}
+
+.game-object.gold .miner-question {
+  top: 9px;
+  right: 34px;
+}

--- a/src/dapp/components/farm/Gold.tsx
+++ b/src/dapp/components/farm/Gold.tsx
@@ -1,32 +1,28 @@
+import "./Trees.css";
+import "./Gold.css";
+
 import { useService } from "@xstate/react";
+import classnames from "classnames";
 import React, { useEffect } from "react";
 import Modal from "react-bootstrap/Modal";
-import classnames from "classnames";
 
-import rock from "../../images/land/gold.png";
 import mining from "../../images/characters/mining.gif";
-import stone from "../../images/ui/gold_ore.png";
-import smallRock from "../../images/decorations/rock2.png";
-import pickaxe from "../../images/ui/iron_pickaxe.png";
-
-import closeIcon from "../../images/ui/close.png";
 import waiting from "../../images/characters/waiting.gif";
-import questionMark from "../../images/ui/expression_confused.png";
-import arrowUp from "../../images/ui/arrow_up.png";
+import smallRock from "../../images/decorations/rock2.png";
+import rock from "../../images/land/gold.png";
 import arrowDown from "../../images/ui/arrow_down.png";
+import arrowUp from "../../images/ui/arrow_up.png";
+import closeIcon from "../../images/ui/close.png";
+import questionMark from "../../images/ui/expression_confused.png";
+import stone from "../../images/ui/gold_ore.png";
+import pickaxe from "../../images/ui/iron_pickaxe.png";
 import timer from "../../images/ui/timer.png";
-
-import { Panel } from "../ui/Panel";
-import { Message } from "../ui/Message";
-import { Button } from "../ui/Button";
-
 import {
   BlockchainEvent,
   BlockchainState,
   Context,
   service,
 } from "../../machine";
-
 import { Inventory, items } from "../../types/crafting";
 
 import "./Trees.css";
@@ -61,7 +57,8 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
 
   useEffect(() => {
     const load = async () => {
-      const strength = await machineState.context.blockChain.getGoldStrength();
+      const strength =
+        await machineState.context.blockChain.getGoldStrength();
       setTreeStrength(Math.floor(Number(strength)));
     };
 
@@ -106,7 +103,10 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
     <>
       {ROCKS.map((gridPosition, index) => {
         const choppedTreeCount = 2 - treeStrength;
-        if (choppedTreeCount > index || machineState.matches("onboarding")) {
+        if (
+          choppedTreeCount > index ||
+          machineState.matches("onboarding")
+        ) {
           return (
             <div style={gridPosition}>
               <img
@@ -136,13 +136,13 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
           >
             <img src={rock} className="rock-mine" alt="tree" />
             {isHighlighted && machineState.matches("mining") && (
-              <>
+              <div className="boundary show-overflow">
                 <img src={mining} className="miner" />
                 <div className="gathered-resource-feedback">
                   <span>+</span>
                   <img src={stone} className="wood-chopped" />
                 </div>
-              </>
+              </div>
             )}
             {showWaiting && (
               <div>
@@ -192,7 +192,8 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
                 </div>
                 {inventory["Iron Pickaxe"] < amount ? (
                   <Message>
-                    You need a <img src={pickaxe} className="required-tool" />
+                    You need a{" "}
+                    <img src={pickaxe} className="required-tool" />
                   </Message>
                 ) : (
                   <div className="gather-resources">
@@ -241,7 +242,9 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
                   href="https://docs.sunflower-farmers.com/resources"
                   target="_blank"
                 >
-                  <h3 className="current-price-supply-demand">Read more</h3>
+                  <h3 className="current-price-supply-demand">
+                    Read more
+                  </h3>
                 </a>
               </div>
             </div>

--- a/src/dapp/components/farm/Gold.tsx
+++ b/src/dapp/components/farm/Gold.tsx
@@ -24,8 +24,9 @@ import {
   service,
 } from "../../machine";
 import { Inventory, items } from "../../types/crafting";
-
-import "./Trees.css";
+import { Button } from "../ui/Button";
+import { Message } from "../ui/Message";
+import { Panel } from "../ui/Panel";
 
 const ROCKS: React.CSSProperties[] = [
   {
@@ -66,7 +67,7 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
       load();
       setAmount(0);
     }
-  }, [machineState.value]);
+  }, [machineState, machineState.value]);
 
   useEffect(() => {
     const change = machineState.context.blockChain.getInventoryChange();
@@ -76,7 +77,7 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
       setShowChoppedCount(true);
       setTimeout(() => setShowChoppedCount(false), 3000);
     }
-  }, [machineState.value, inventory]);
+  }, [machineState.value, inventory, machineState.context.blockChain]);
 
   const chop = () => {
     send("MINE", {
@@ -128,13 +129,13 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
         return (
           <div
             style={gridPosition}
-            className={classnames("gather-tree", {
+            className={classnames("gather-tree", "game-object", "gold", {
               "gatherer-selected": isHighlighted,
               gatherer: isNextToChop,
             })}
             onClick={isNextToChop ? open : undefined}
           >
-            <img src={rock} className="rock-mine" alt="tree" />
+            <img src={rock} className="rock-mine ore" alt="tree" />
             {isHighlighted && machineState.matches("mining") && (
               <div className="boundary show-overflow">
                 <img src={mining} className="miner" />
@@ -145,7 +146,7 @@ export const Gold: React.FC<Props> = ({ inventory }) => {
               </div>
             )}
             {showWaiting && (
-              <div>
+              <div className="boundary">
                 <img src={waiting} className="miner" />
                 <img src={questionMark} className="miner-question" />
               </div>


### PR DESCRIPTION
This solves issue #62 by enabling `overflow` only when the mining animation is playing.