### PR TITLE
[FIX] 2days bug - Floor hatchTime when getting time difference

### DIFF
--- a/src/dapp/components/farm/Chickens.tsx
+++ b/src/dapp/components/farm/Chickens.tsx
@@ -56,7 +56,7 @@ export const Chickens: React.FC<Props> = ({ inventory }) => {
         return;
       }
 
-      const difference = Math.floor(Date.now() / 1000) - hatchTime;
+      const difference = Math.floor(Date.now() / 1000 - hatchTime);
       const timeLeft = 60 * 60 * 24 - difference;
 
       if (timeLeft <= 0) {


### PR DESCRIPTION
this PR aims to resolve issue #58 

Changes:
- included `hatchTime` inside `Math.floor()` when getting `difference`

I was testing hoping to get a screenshot but alas, I got pending tx modal and had to refresh the page. If any of you lads can test this before I do tomorrow, feel free to do so and point out corrections if any. Thanks!