### PR TITLE
Add toFixed to plant price

### DIFF
--- a/src/dapp/components/ui/Plants.tsx
+++ b/src/dapp/components/ui/Plants.tsx
@@ -84,13 +84,13 @@ export const Plants: React.FC<Props> = ({
                 <div>
                   <span className="ingredient-count">Plant</span>
                 </div>
-                <span className="ingredient-text">{`${plant.buyPrice} $SFF`}</span>
+                <span className="ingredient-text">{`${plant.buyPrice.toFixed(4)} $SFF`}</span>
               </div>
               <div className="ingredient">
                 <div>
                   <span className="ingredient-count">Harvest</span>
                 </div>
-                <span className="ingredient-text">{`${plant.sellPrice} $SFF `}</span>
+                <span className="ingredient-text">{`${plant.sellPrice.toFixed(4)} $SFF `}</span>
               </div>
             </div>
           </>


### PR DESCRIPTION
After the 1Mil halving the plant price had too many zeros. 
This PR will cap it to 4.

BEFORE:
![Screen Shot 2022-01-02 at 4 43 01 am](https://user-images.githubusercontent.com/25412194/147857012-afb74ef9-7296-4a79-a8a4-67c567bbf34c.png)

AFTER:
![Screen Shot 2022-01-02 at 4 56 26 am](https://user-images.githubusercontent.com/25412194/147857044-cccab085-06f3-40fd-b179-d06676605dfc.png)

