### PR TITLE
Fix incorrect value for getMarketRate after supply hits >=1b tokens

### DIFF
--- a/src/contracts/Farm.sol
+++ b/src/contracts/Farm.sol
@@ -462,7 +462,7 @@ contract FarmV2 {
         }
 
         // 1 Farm Dollar gets you a 0.00001 of a token - Linear growth from here
-        return totalSupply.div(10000);
+        return totalSupply.div(10000 * 10**decimals);
     }
 
     function getMarketPrice(uint price) public view returns (uint conversion) {


### PR DESCRIPTION
after token totalSupply reaches 1e27 (1 billion tokens), the market rate becomes totalSupply / 10000

that's >= 1e23, or 100 sextillion, instead of the intended 100000

which means that seed/fruit/land prices will become 0 (since they're all much lower than 1e23)