### PR TITLE
[FIX] Display nextHalvingThreshold in the MarketModal

### DIFF
--- a/src/dapp/components/ui/MarketModal.tsx
+++ b/src/dapp/components/ui/MarketModal.tsx
@@ -13,6 +13,7 @@ import {
   getNextHalvingThreshold,
   getNextMarketRate,
 } from "../../utils/supply";
+import { numberWithBreaks } from "../../utils/number";
 
 import "./MarketModal.css";
 
@@ -68,7 +69,7 @@ export const MarketModal: React.FC<Props> = ({ isOpen, onClose }) => {
             {nextHalvingThreshold ? (
               <p className="current-price-info">
                 The next halvening event will occur when total supply reaches{" "}
-                {nextHalvingThreshold.toLocaleString()} tokens
+                {numberWithBreaks(nextHalvingThreshold.amount)} tokens
               </p>
             ) : (
               <p className="current-price-info">No more halvening events!</p>


### PR DESCRIPTION
The current version of MarkeModal its not using the amount variable, from nextHalvingThreshold object, ocurring in a wrong exihbition of next halving threshold. Changed to use the amount variable and to format in the screen its using numberWithBreaks from util/number. 