### PR TITLE
[FIX] Halving amount display bug

### DIFF
--- a/src/dapp/components/ui/MarketModal.tsx
+++ b/src/dapp/components/ui/MarketModal.tsx
@@ -68,7 +68,7 @@ export const MarketModal: React.FC<Props> = ({ isOpen, onClose }) => {
             {nextHalvingThreshold ? (
               <p className="current-price-info">
                 The next halvening event will occur when total supply reaches{" "}
-                {nextHalvingThreshold.toLocaleString()} tokens
+                {nextHalvingThreshold.amount.toLocaleString()} tokens
               </p>
             ) : (
               <p className="current-price-info">No more halvening events!</p>


### PR DESCRIPTION
reported by Rain from discord
https://discord.com/channels/880987707214544966/881648372249939980/927675711311986728

Before
![image](https://user-images.githubusercontent.com/89294757/147991624-d3e83d1b-6dfa-4e4d-9450-abcb2de92774.png)

Fix:
- access `amount` prop
